### PR TITLE
Fix custom umbraco dictionary keys not working once again

### DIFF
--- a/src/Our.Umbraco.DataAnnotations/UmbracoCompareAttribute.cs
+++ b/src/Our.Umbraco.DataAnnotations/UmbracoCompareAttribute.cs
@@ -16,11 +16,12 @@ namespace Our.Umbraco.DataAnnotations
         public UmbracoCompareAttribute(string otherProperty)
             : base(otherProperty)
         {
-            ErrorMessageString = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
         }
 
         public IEnumerable<ModelClientValidationRule> GetClientValidationRules(ModelMetadata metadata, ControllerContext context)
         {
+            ErrorMessageString = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
+
             if (metadata.ContainerType != null)
             {
                 if (OtherPropertyDisplayName == null)

--- a/src/Our.Umbraco.DataAnnotations/UmbracoMaxLengthAttribute.cs
+++ b/src/Our.Umbraco.DataAnnotations/UmbracoMaxLengthAttribute.cs
@@ -15,11 +15,12 @@ namespace Our.Umbraco.DataAnnotations
         public UmbracoMaxLengthAttribute(int length)
             : base(length)
         {
-            ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
         }
 
         public IEnumerable<ModelClientValidationRule> GetClientValidationRules(ModelMetadata metadata, ControllerContext context)
         {
+            ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
+
             yield return
                 new ModelClientValidationMaxLengthRule(FormatErrorMessage(metadata.GetDisplayName()), Length);
         }

--- a/src/Our.Umbraco.DataAnnotations/UmbracoMinLengthAttribute.cs
+++ b/src/Our.Umbraco.DataAnnotations/UmbracoMinLengthAttribute.cs
@@ -15,11 +15,12 @@ namespace Our.Umbraco.DataAnnotations
         public UmbracoMinLengthAttribute(int length)
             : base(length)
         {
-            ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
         }
 
         public IEnumerable<ModelClientValidationRule> GetClientValidationRules(ModelMetadata metadata, ControllerContext context)
         {
+            ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
+
             yield return
                 new ModelClientValidationMinLengthRule(FormatErrorMessage(metadata.GetDisplayName()), Length);
         }

--- a/src/Our.Umbraco.DataAnnotations/UmbracoRangeAttribute.cs
+++ b/src/Our.Umbraco.DataAnnotations/UmbracoRangeAttribute.cs
@@ -12,11 +12,12 @@ namespace Our.Umbraco.DataAnnotations
         public UmbracoRangeAttribute(int minimum, int maximum) 
             : base(minimum, maximum)
         {
-            ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
         }
 
         public IEnumerable<ModelClientValidationRule> GetClientValidationRules(ModelMetadata metadata, ControllerContext context)
         {
+            ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
+
             yield return
                 new ModelClientValidationRangeRule(FormatErrorMessage(metadata.GetDisplayName()), Minimum, Maximum);
         }

--- a/src/Our.Umbraco.DataAnnotations/UmbracoRegularExpressionAttribute.cs
+++ b/src/Our.Umbraco.DataAnnotations/UmbracoRegularExpressionAttribute.cs
@@ -15,11 +15,12 @@ namespace Our.Umbraco.DataAnnotations
         public UmbracoRegularExpressionAttribute(string pattern)
             : base(pattern)
         {
-            ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
         }
 
         public IEnumerable<ModelClientValidationRule> GetClientValidationRules(ModelMetadata metadata, ControllerContext context)
         {
+            ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
+
             yield return new ModelClientValidationRegexRule(FormatErrorMessage(metadata.GetDisplayName()), Pattern);
         }
     }

--- a/src/Our.Umbraco.DataAnnotations/UmbracoRequiredAttribute.cs
+++ b/src/Our.Umbraco.DataAnnotations/UmbracoRequiredAttribute.cs
@@ -15,11 +15,11 @@ namespace Our.Umbraco.DataAnnotations
         public UmbracoRequiredAttribute() 
             : base()
         {
-            ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
         }
 
         public IEnumerable<ModelClientValidationRule> GetClientValidationRules(ModelMetadata metadata, ControllerContext context)
         {
+            ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
             yield return new ModelClientValidationRequiredRule(FormatErrorMessage(metadata.GetDisplayName()));
         }
     }

--- a/src/Our.Umbraco.DataAnnotations/UmbracoStringLengthAttribute.cs
+++ b/src/Our.Umbraco.DataAnnotations/UmbracoStringLengthAttribute.cs
@@ -15,11 +15,12 @@ namespace Our.Umbraco.DataAnnotations
         public UmbracoStringLengthAttribute(int maximumLength)
             : base(maximumLength)
         {
-            ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
         }
 
         public IEnumerable<ModelClientValidationRule> GetClientValidationRules(ModelMetadata metadata, ControllerContext context)
         {
+            ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
+
             yield return
                 new ModelClientValidationStringLengthRule(FormatErrorMessage(metadata.GetDisplayName()), MinimumLength, MaximumLength);
         }


### PR DESCRIPTION
I tested with your latest changes and it stopped working again.

I think it is because of the following (Required attribute as example):

Below code will execute only once and for some reason the ErrorMessage will always be the default one even when the DictionaryKey property has been set on my model.
```
 public UmbracoRequiredAttribute() 
		: base()
	{
		ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
	}
```
If we put that line over here, it will execute everytime the page is reloaded. This seems to work just fine and reads the value set in the dictionary. I tested it and it does not seem to break the default behaviour if no DictionaryKey has been set on the model.
```
public IEnumerable<ModelClientValidationRule> GetClientValidationRules(ModelMetadata metadata, ControllerContext context)
{
	ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
	yield return new ModelClientValidationRequiredRule(FormatErrorMessage(metadata.GetDisplayName()));
}
```

So in conclusion while I was debugging and once the UmbracoRequiredAttribute constructor was executed the dictionary key was still the default one which is "RequiredError" in this case, even though I set the property on my model to be something else.

It only seems to be applying the value I set on the property in the GetClientValidationRules method. (for some unknown reason, because I also don't understand why it shouldn't be able to read my set property value when executing the constructor.)