### PR TITLE
Fixed UmbracoMustBeTrue and UmbracoCompare attributes

### DIFF
--- a/src/Our.Umbraco.DataAnnotations/UmbracoCompareAttribute.cs
+++ b/src/Our.Umbraco.DataAnnotations/UmbracoCompareAttribute.cs
@@ -10,7 +10,6 @@ namespace Our.Umbraco.DataAnnotations
     public sealed class UmbracoCompareAttribute : System.ComponentModel.DataAnnotations.CompareAttribute, IClientValidatable, IUmbracoValidationAttribute
     {
         public string DictionaryKey { get; set; } = "EqualToError";
-        public new string ErrorMessageString { get; set; }
         public new string OtherPropertyDisplayName { get; set; }
 
         public UmbracoCompareAttribute(string otherProperty)
@@ -20,7 +19,7 @@ namespace Our.Umbraco.DataAnnotations
 
         public IEnumerable<ModelClientValidationRule> GetClientValidationRules(ModelMetadata metadata, ControllerContext context)
         {
-            ErrorMessageString = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
+            ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
 
             if (metadata.ContainerType != null)
             {

--- a/src/Our.Umbraco.DataAnnotations/UmbracoMustBeTrueAttribute.cs
+++ b/src/Our.Umbraco.DataAnnotations/UmbracoMustBeTrueAttribute.cs
@@ -11,10 +11,6 @@ namespace Our.Umbraco.DataAnnotations
     {
         public string DictionaryKey { get; set; } = "MustBeTrueError";
 
-        public UmbracoMustBeTrueAttribute()
-        {
-            ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
-        }
 
         public override bool IsValid(object value)
         {
@@ -23,6 +19,8 @@ namespace Our.Umbraco.DataAnnotations
 
         public IEnumerable<ModelClientValidationRule> GetClientValidationRules(ModelMetadata metadata, ControllerContext context)
         {
+            ErrorMessage = UmbracoDictionary.GetDictionaryValue(DictionaryKey);
+
             var rule = new ModelClientValidationRule()
             {
                 ValidationType = "mustbetrue",


### PR DESCRIPTION
Did some more fixes to attributes that didn't behave as I expected initially. 

For example UmbracoCompare didn't even take the Dictionary Key in account at all (even the default one).