### PR TITLE
ErrorMessage set in ctor

### DIFF
--- a/src/Our.Umbraco.DataAnnotations/UmbracoMustBeTrueAttribute.cs
+++ b/src/Our.Umbraco.DataAnnotations/UmbracoMustBeTrueAttribute.cs
@@ -13,7 +13,6 @@ namespace Our.Umbraco.DataAnnotations
 
         public UmbracoMustBeTrueAttribute()
         {
-            ErrorMessage = UmbracoDictionary.DictionaryValue(DictionaryKey);
         }
 
         public override bool IsValid(object value)
@@ -23,6 +22,7 @@ namespace Our.Umbraco.DataAnnotations
 
         public IEnumerable<ModelClientValidationRule> GetClientValidationRules(ModelMetadata metadata, ControllerContext context)
         {
+            ErrorMessage = UmbracoDictionary.DictionaryValue(DictionaryKey);
             var rule = new ModelClientValidationRule()
             {
                 ValidationType = "mustbetrue",


### PR DESCRIPTION
ErrorMessage is set in ctor, before it has been possible to set the DictionaryKey